### PR TITLE
Fix typo in section title

### DIFF
--- a/core/sections/clause_15_parameter_values.adoc
+++ b/core/sections/clause_15_parameter_values.adoc
@@ -1,4 +1,4 @@
-== Requirements Class "Symbolizer Parameter Value Expresssions"
+== Requirements Class "Symbolizer Parameter Value Expressions"
 === Overview
 
 This requirements class adds support for using **ParameterValues** i.e., arbitrary **Expressions** (not only literals), for all **Symbolizer** properties.


### PR DESCRIPTION
This fixes a typo in the title of the Requirements Class `Symbolizer Value Expressions`