### PR TITLE
Minor updates to CartoSym-JSON.schema.json

### DIFF
--- a/1-core/schemas/CartoSym-JSON.schema.json
+++ b/1-core/schemas/CartoSym-JSON.schema.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$ref": "#/$defs/style",
+  "allOf": [{
+    "$ref": "#/$defs/style"
+  }],
   "$defs": {
     "style": {
       "type": "object",
@@ -1995,8 +1997,8 @@
           "maxItems": 3,
           "prefixItems": [
              { "$dynamicRef": "#boolExpression" },
-             { "$ref": "anyExpression" },
-             { "$ref": "anyExpression" }
+             { "$ref": "#/$defs/anyExpression" },
+             { "$ref": "#/$defs/anyExpression" }
           ]
         }
       }


### PR DESCRIPTION
This adds two minor changes to the JSON schema of the CartoSym.

1. It fixes a broken ref to the `anyExpression` definition
2. It replaces the toplevel `"$ref"` with `"allOf": [ … ]`

The impact of this change shoud be quite small but follows a bit stricter to the [spec](https://datatracker.ietf.org/doc/html/draft-pbryan-zyp-json-ref-03#section-3) as [some software](https://github.com/bcherny/json-schema-to-typescript/issues/132#issuecomment-345305800) will fail on parsing this schema.